### PR TITLE
fix distored pixel buffer

### DIFF
--- a/Extension/ExtensionProvider.swift
+++ b/Extension/ExtensionProvider.swift
@@ -252,7 +252,7 @@ class ExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
                       width: width,
                       height: height,
                       bitsPerComponent: image.bitsPerComponent,
-                      bytesPerRow: image.bytesPerRow,
+                      bytesPerRow: CVPixelBufferGetBytesPerRow(pixelBuffer),
                       space: colorspace,
                       bitmapInfo: CGImageAlphaInfo.noneSkipFirst
                           .rawValue)


### PR DESCRIPTION
According to [this page](https://www.appsloveworld.com/coding/ios/98/create-cvpixelbuffer-with-pixels-data-but-the-final-image-is-distorted?expand_article=1) to fix the distoration of pixel buffer.

This works in XCode 15.0 with Swift 5.9.